### PR TITLE
fix: correct router usage in register page and deduplicate edit button in vendor page

### DIFF
--- a/client/app/register/[inviteId]/page.tsx
+++ b/client/app/register/[inviteId]/page.tsx
@@ -7,11 +7,12 @@ import HowToRegIcon from "@mui/icons-material/HowToReg";
 import { useEffect, useState } from "react";
 import { getInvite, registerByInvite } from "@/entities/auth/auth-api";
 import React from "react";
-import router from "next/navigation";
+import { useRouter } from "next/navigation";
 
 
 export default function RegisterPage({ params }: { params: Promise<{ inviteId: string }> }) {
   const { inviteId } = React.use(params);
+  const router = useRouter();
 
   const [userName, setUserName] = useState<string>("");
   const [firstName, setFirstName] = useState<string>("");
@@ -23,7 +24,7 @@ export default function RegisterPage({ params }: { params: Promise<{ inviteId: s
       try {
         await getInvite(Number(inviteId));
       } catch {
-        router.redirect("/login");
+        router.push("/login");
       }
     };
     checkInvite();
@@ -31,7 +32,7 @@ export default function RegisterPage({ params }: { params: Promise<{ inviteId: s
 
   const handleRegister = async () => {
     await registerByInvite(Number(inviteId), { userName, firstName, lastName, password });
-    router.redirect("/login");
+    router.push("/login");
   };
 
   return (

--- a/client/app/vendor/page.tsx
+++ b/client/app/vendor/page.tsx
@@ -72,19 +72,25 @@ export default function VendorPage() {
             </Typography>
             <Chip label="Vendor" size="small" sx={{ bgcolor: "rgba(233,69,96,0.15)", color: "#e94560", fontWeight: 700, mt: 0.5 }} />
           </Box>
-          {isEditing 
-          ? <Button onClick={handleSave}>Save</Button> 
-          : <Button onClick={handleEdit}>Edit</Button>
-}
         </Box>
-        <Button
-          variant="outlined"
-          startIcon={<EditIcon />}
-          onClick={handleEdit}
-          sx={{ borderColor: "#e94560", color: "#e94560", "&:hover": { bgcolor: "rgba(233,69,96,0.1)", borderColor: "#e94560" } }}
-        >
-          Редактировать
-        </Button>
+        {isEditing
+          ? <Button
+              variant="outlined"
+              startIcon={<SaveIcon />}
+              onClick={handleSave}
+              sx={{ borderColor: "#e94560", color: "#e94560", "&:hover": { bgcolor: "rgba(233,69,96,0.1)", borderColor: "#e94560" } }}
+            >
+              Сохранить
+            </Button>
+          : <Button
+              variant="outlined"
+              startIcon={<EditIcon />}
+              onClick={handleEdit}
+              sx={{ borderColor: "#e94560", color: "#e94560", "&:hover": { bgcolor: "rgba(233,69,96,0.1)", borderColor: "#e94560" } }}
+            >
+              Редактировать
+            </Button>
+        }
       </Box>
       <Divider sx={{ borderColor: "rgba(255,255,255,0.08)", mb: 4 }} />
 


### PR DESCRIPTION
 - `app/register/[inviteId]/page.tsx`: replaced default import of `next/navigation` with `useRouter` hook; replaced
    non-existent `router.redirect()` calls with `router.push()`
   - `app/vendor/page.tsx`: removed duplicate unstyled Edit/Save buttons; single styled button now toggles between
   Edit and Save states